### PR TITLE
allow multidim sparsity in topk saes

### DIFF
--- a/benchmark/bench_fwd_perf.py
+++ b/benchmark/bench_fwd_perf.py
@@ -5,7 +5,6 @@ from typing import Any, Callable
 import torch
 import torch._inductor.config
 import triton
-from sparsify import SparseCoder, SparseCoderConfig
 from tabulate import tabulate
 
 from sae_lens.saes.sae import TrainStepInput
@@ -54,9 +53,6 @@ cfg_dense = build_topk_sae_training_cfg(
 
 sae_sparse = TopKTrainingSAE(cfg_sparse)
 sae_dense = TopKTrainingSAE(cfg_dense)
-sparse_coder_sae = SparseCoder(
-    d_in=d_in, cfg=SparseCoderConfig(num_latents=d_sae, k=26)
-)
 
 dead_neuron_mask = None  # torch.randn(d_sae, device = device) > 0.1
 input_acts = torch.randn(seq_len, d_in, device=device)

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -466,6 +466,8 @@ def get_sparsity_and_variance_metrics(
         sae_out_scaled = sae.decode(sae_feature_activations).to(
             original_act_scaled.device
         )
+        if sae_feature_activations.is_sparse:
+            sae_feature_activations = sae_feature_activations.to_dense()
         del cache
 
         sae_out = activation_scaler.unscale(sae_out_scaled)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -235,6 +235,15 @@ def _build_runner_config(
     return final_config
 
 
+def _update_sae_metadata(runner_cfg: LanguageModelSAERunnerConfig[Any]):
+    runner_cfg.sae.metadata.hook_name = runner_cfg.hook_name
+    runner_cfg.sae.metadata.hook_head_index = runner_cfg.hook_head_index
+    runner_cfg.sae.metadata.model_name = runner_cfg.model_name
+    runner_cfg.sae.metadata.model_class_name = runner_cfg.model_class_name
+    runner_cfg.sae.metadata.dataset_path = runner_cfg.dataset_path
+    runner_cfg.sae.metadata.prepend_bos = runner_cfg.prepend_bos
+
+
 # --- Standard SAE Builder ---
 def build_runner_cfg(
     **kwargs: Any,
@@ -257,12 +266,7 @@ def build_runner_cfg(
         cast(dict[str, Any], default_sae_config),
         **kwargs,
     )
-    runner_cfg.sae.metadata.hook_name = runner_cfg.hook_name
-    runner_cfg.sae.metadata.hook_head_index = runner_cfg.hook_head_index
-    runner_cfg.sae.metadata.model_name = runner_cfg.model_name
-    runner_cfg.sae.metadata.model_class_name = runner_cfg.model_class_name
-    runner_cfg.sae.metadata.dataset_path = runner_cfg.dataset_path
-    runner_cfg.sae.metadata.prepend_bos = runner_cfg.prepend_bos
+    _update_sae_metadata(runner_cfg)
     return runner_cfg
 
 
@@ -302,11 +306,13 @@ def build_jumprelu_runner_cfg(
         "l0_warm_up_steps": 0,
         "pre_act_loss_coefficient": None,
     }
-    return _build_runner_config(
+    runner_cfg = _build_runner_config(
         JumpReLUTrainingSAEConfig,
         cast(dict[str, Any], default_sae_config),
         **kwargs,
     )
+    _update_sae_metadata(runner_cfg)
+    return runner_cfg
 
 
 def build_jumprelu_sae_cfg(**kwargs: Any) -> JumpReLUSAEConfig:
@@ -340,11 +346,13 @@ def build_gated_runner_cfg(
         "apply_b_dec_to_input": False,
         "l1_warm_up_steps": 0,
     }
-    return _build_runner_config(
+    runner_cfg = _build_runner_config(
         GatedTrainingSAEConfig,
         cast(dict[str, Any], default_sae_config),
         **kwargs,
     )
+    _update_sae_metadata(runner_cfg)
+    return runner_cfg
 
 
 def build_gated_sae_cfg(**kwargs: Any) -> GatedSAEConfig:
@@ -385,11 +393,13 @@ def build_topk_runner_cfg(
     # Update the default config *before* passing it to _build_runner_config
     final_default_sae_config = cast(dict[str, Any], temp_sae_config)
 
-    return _build_runner_config(
+    runner_cfg = _build_runner_config(
         TopKTrainingSAEConfig,
         final_default_sae_config,
         **kwargs,
     )
+    _update_sae_metadata(runner_cfg)
+    return runner_cfg
 
 
 def build_topk_sae_cfg(**kwargs: Any) -> TopKSAEConfig:
@@ -432,11 +442,13 @@ def build_batchtopk_runner_cfg(
     # Update the default config *before* passing it to _build_runner_config
     final_default_sae_config = cast(dict[str, Any], temp_sae_config)
 
-    return _build_runner_config(
+    runner_cfg = _build_runner_config(
         BatchTopKTrainingSAEConfig,
         final_default_sae_config,
         **kwargs,
     )
+    _update_sae_metadata(runner_cfg)
+    return runner_cfg
 
 
 def build_batchtopk_sae_training_cfg(**kwargs: Any) -> BatchTopKTrainingSAEConfig:

--- a/tests/refactor_compatibility/test_topk_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_topk_sae_equivalence.py
@@ -119,7 +119,6 @@ def test_topk_sae_inference_equivalence():
     """
     old_sae = make_old_topk_sae(d_in=16, d_sae=8, use_error_term=False)
     new_sae = make_new_topk_sae(d_in=16, d_sae=8, use_error_term=False)
-    new_sae.disable_sparse_activations()
 
     compare_params(old_sae, new_sae)
 
@@ -151,7 +150,6 @@ def test_topk_sae_inference_equivalence():
     # Now test with error_term
     old_sae_err = make_old_topk_sae(d_in=16, d_sae=8, use_error_term=True)
     new_sae_err = make_new_topk_sae(d_in=16, d_sae=8, use_error_term=True)
-    new_sae_err.disable_sparse_activations()
 
     # Align error term model parameters
     with torch.no_grad():
@@ -184,7 +182,6 @@ def test_topk_sae_run_with_cache_equivalence():  # type: ignore
 
     old_sae = make_old_topk_sae()
     new_sae = make_new_topk_sae()
-    new_sae.disable_sparse_activations()
 
     # Ensure parameters are identical before comparing outputs
     with torch.no_grad():
@@ -272,7 +269,6 @@ def test_topk_sae_training_equivalence():
         d_sae=8,
     )
     new_training_sae = TopKTrainingSAE(new_training_cfg)
-    new_training_sae.disable_sparse_activations()
 
     # Compare param shapes using updated compare_params
     compare_params(old_training_sae, new_training_sae)
@@ -317,7 +313,7 @@ def test_topk_sae_training_equivalence():
     )
     assert_close(
         old_out.feature_acts,
-        new_out.feature_acts,
+        new_out.feature_acts.to_dense(),
         atol=1e-5,
         msg="Training feature_acts differ between old and new implementations.",
     )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from sae_lens.util import extract_stop_at_layer_from_tlens_hook_name, path_or_tmp_dir
+from sae_lens.util import (
+    extract_stop_at_layer_from_tlens_hook_name,
+    path_or_tmp_dir,
+)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I tried testing out the topk training, but it failed, as expected, on evals where 3d tensors were getting passed in. I tried to see if I could just get it to work with multi-dim tensors. This is what I came up with. Does this seem reasonable? As far as I can tell this will work with any dim tensor. Most of the meat of the code is from Claude, it claims it doesn't harm performance to do the sparse multiply this way, but I haven't benchmarked it. I figured if we can just make stuff work with any dim of sparse tensors that would solve most of the issues anyway.